### PR TITLE
hint about 'as' type assertions for JSX code

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,14 +392,14 @@ Programmatically checking for types work eactly as it works in JavaScript:
 > Sometimes you’ll end up in a situation where you’ll know more about a value than TypeScript does. Usually this will happen when you know the type of some entity could be more specific than its current type.
 > Type assertions are a way to tell the compiler “trust me, I know what I’m doing”. A type assertion is like a type cast in other languages, but performs no special checking or restructuring of data. It has no runtime impact, and is used purely by the compiler. TypeScript assumes that you, the programmer, have performed any special checks that you need.
 
-Type assertions have two forms. One is the “angle-bracket” syntax:
+Type assertions have two forms. One is the “angle-bracket” syntax, which is fine, except for JSX (read React) code because JSX works with angle-bracket syntax itself:
 
 ```ts
   const someValue: any = "this is a string";
   const strLength: number = (<string>someValue).length;
 ```
 
-And the other is the `as`-syntax:
+And the other is the one used with JSX, namely the `as`-syntax:
 
 ```ts
   const someValue: any = "this is a string";


### PR DESCRIPTION
with JSX we need to use 'as' instead of `<>`