### PR TITLE
Fix Incorrect & Confusing statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ TypeScript offers `public`, `private`, and protected modifiers to every class me
 
 ## Private Members
 
-When a member is marked `private`, it cannot be accessed from outside of its containing class. **However, should a class `X` inherit properties from `Person`, class `A` will be able to access all private properties from `Person` (e.g. `type and setType`) due to being inside (or having access to) the protected scope**. More on what class inheritance is all about just below, but here's an example;
+When a class inherits from another class, private members of the parent class are not accessible directly in the child class. Instead, interaction with private members can only be done through public or protected methods of the parent class.
 
 ```ts
   class Type {


### PR DESCRIPTION
### Original statement 
"However, should a class X inherit properties from Person, class A will be able to access all private properties from Person (e.g., type and setType) due to being inside (or having access to) the protected scope."

is confusing
because example snippet doesn't have any `X` or `A` class for context.
and also incorrect
as private members of class cannot be inherited by subclass without public methods exposed by parent class.

### Rephrased and Improved Explanation:
"When a member is marked as private, it cannot be accessed from outside of its containing class, including subclasses. For example, in the provided code, the type property in the Type class is private and cannot be accessed directly by the Person class, even though Person extends Type. However, the setType method is public, so it can be called from within Person or any other context to modify the type property."

